### PR TITLE
fix: CI green — gofmt + install native deps for go test in deploy-wasm

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -25,10 +25,10 @@ func TestAbs(t *testing.T) {
 func TestCheckCollisionWithThreshold(t *testing.T) {
 	g := &Game{}
 	cases := []struct {
-		name           string
-		a, b           FloatPosition
-		threshold      float64
-		wantCollision  bool
+		name          string
+		a, b          FloatPosition
+		threshold     float64
+		wantCollision bool
 	}{
 		{"identical", FloatPosition{1, 1}, FloatPosition{1, 1}, 0.5, true},
 		{"inside threshold", FloatPosition{0, 0}, FloatPosition{0.3, 0.3}, 0.5, true},


### PR DESCRIPTION
## Summary

Two follow-up fixes to #9. Both CI workflows are currently failing on `main`:

1. **`build.yml`** fails on `go fmt ./... && git diff --exit-code` because `cmd/cmd_test.go` has misaligned struct-literal fields in `TestCheckCollisionWithThreshold`.
2. **`deploy-wasm.yml`** fails on the new `go test ./...` step because the `cmd` package imports Ebiten, which pulls in CGO on GLFW/X11/ALSA for native compilation. The WASM build itself doesn't need these deps (`GOOS=js GOARCH=wasm` disables CGO), but `go test` compiles natively.

### Commits

- `a97746d` — `gofmt -w` on `cmd/cmd_test.go`. Removes one space of padding in four field declarations. No behavior change.
- `d072040` — Install `libasound2-dev libx11-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libgl-dev libxxf86vm-dev` in `deploy-wasm.yml` before the test step. Matches what `build.yml` already does.

## Test plan

- [x] `go fmt ./... && git diff --exit-code` — clean
- [x] `go test ./...` — all 20 tests pass locally
- [x] `go vet ./...` — clean
- [ ] `build.yml` passes on PR
- [ ] `deploy-wasm.yml` passes after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)