### PR TITLE
ci: install X11/ALSA dev deps in deploy-wasm before go test

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -30,6 +30,14 @@ jobs:
           GOOS=js GOARCH=wasm go vet ./...
           go fmt ./... && git diff --exit-code
 
+      - name: Install system dependencies for native test compilation
+        # cmd/ tests import the cmd package which transitively pulls in
+        # Ebiten's CGO (GLFW/X11/ALSA). The WASM build itself doesn't need
+        # these, but go test ./... must compile the package natively.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libx11-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libgl-dev libxxf86vm-dev
+
       - name: Run tests
         run: go test ./...
 


### PR DESCRIPTION
## Summary

`deploy-wasm.yml` on `main` is failing on the `go test ./...` step with:

```
./glfw3native_unix.h:105:12: fatal error: X11/Xlib.h: No such file or directory
Package 'alsa', required by 'virtual:world', not found
```

The `cmd` package imports Ebiten, which pulls in CGO on GLFW/X11/ALSA for native compilation. The WASM build itself doesn't need these deps (`GOOS=js GOARCH=wasm` disables CGO), but `go test` compiles each package natively and needs the headers.

This installs the same dev headers that `build.yml` already installs, immediately before the test step.

This commit was originally staged for PR #10 but was pushed after that PR was merged, so it didn't land.

## Test plan

- [ ] `deploy-wasm.yml` passes on this PR's run
- [ ] After merge, main's `deploy-wasm.yml` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)