### PR TITLE
ci: wrap go test in xvfb-run for headless Ebiten init

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -34,12 +34,14 @@ jobs:
         # cmd/ tests import the cmd package which transitively pulls in
         # Ebiten's CGO (GLFW/X11/ALSA). The WASM build itself doesn't need
         # these, but go test ./... must compile the package natively.
+        # xvfb provides a virtual X display for Ebiten's GLFW init() which
+        # runs at package-load time even when RunGame isn't invoked.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libx11-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libgl-dev libxxf86vm-dev
+          sudo apt-get install -y libasound2-dev libx11-dev libxrandr-dev libxcursor-dev libxinerama-dev libxi-dev libgl-dev libxxf86vm-dev xvfb
 
       - name: Run tests
-        run: go test ./...
+        run: xvfb-run -a go test ./...
 
       - name: Build release WASM binary
         # Release flags:


### PR DESCRIPTION
## Summary

Follow-up to #11. With the X11/ALSA headers installed, the `cmd` package now compiles, but the test binary still panics at startup:

```
glfw: X11: The DISPLAY environment variable is missing
panic: glfw: The GLFW library is not initialized
    /go/pkg/mod/github.com/hajimehoshi/ebiten/v2@v2.9.9/internal/ui/ui.go:101
```

Ebiten's `internal/ui` package calls `glfwInit()` from a package-level `init()` — which runs even when `RunGame` is never invoked. On Ubuntu CI there is no X display, so init panics.

Fix: install `xvfb` and wrap `go test ./...` with `xvfb-run -a`. `-a` auto-picks a free server number and tears it down on exit. This is the standard pattern for headless Ebiten / GLFW testing.

## Test plan

- [ ] `deploy-wasm.yml` test step passes on this PR's run
- [ ] After merge, main's `deploy-wasm.yml` is fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)