### PR TITLE
ci: enable WASM post-MVP features for wasm-opt

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -54,12 +54,22 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y binaryen
 
       - name: Optimise WASM binary size
-        # wasm-opt -O4 typically reduces Go WASM binary size by 15-25%
+        # wasm-opt -O4 typically reduces Go WASM binary size by 15-25%.
         # --strip-debug / --strip-producers remove any remaining metadata.
+        # Feature flags: Go's WASM backend emits bulk memory operations
+        # (memory.copy, memory.fill) and sign-extension / non-trapping
+        # float-to-int instructions. Ubuntu's binaryen 108 rejects these
+        # unless the matching features are explicitly enabled.
         run: |
           wasm-opt --version
           ls -l godaleks.wasm
-          wasm-opt -O4 --strip-debug --strip-producers godaleks.wasm -o godaleks.wasm
+          wasm-opt \
+            --enable-bulk-memory \
+            --enable-sign-ext \
+            --enable-nontrapping-float-to-int \
+            --enable-mutable-globals \
+            -O4 --strip-debug --strip-producers \
+            godaleks.wasm -o godaleks.wasm
           ls -l godaleks.wasm
 
       - name: Copy wasm_exec.js from Go installation


### PR DESCRIPTION
## Summary

Follow-up to #12. With `xvfb` in place, tests pass — but now the `wasm-opt` step fails on Ubuntu's binaryen v108:

```
[wasm-validator error in function 312] Bulk memory operation (bulk memory is disabled), on (memory.copy ...)
[wasm-validator error in function 372] Bulk memory operation (bulk memory is disabled), on (memory.fill ...)
```

Go 1.21+'s WASM backend emits bulk-memory and sign-extension / non-trapping-float-to-int instructions. Ubuntu's binaryen disables these post-MVP features by default. They're universally supported by every browser that runs WASM today, so enabling them is safe.

Adds the four feature flags Go's output requires to the `wasm-opt` invocation:

- `--enable-bulk-memory`
- `--enable-sign-ext`
- `--enable-nontrapping-float-to-int`
- `--enable-mutable-globals`

## Test plan

- [ ] `wasm-opt` step completes and reports a smaller binary size than the pre-opt `ls -l`
- [ ] After merge, main's `deploy-wasm.yml` runs end-to-end green and publishes the optimised WASM bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)